### PR TITLE
fix(rss): normalize stale proxied image URLs in feeds

### DIFF
--- a/tests/test_image_proxy.py
+++ b/tests/test_image_proxy.py
@@ -1,0 +1,41 @@
+import unittest
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "utils" / "image_proxy.py"
+spec = importlib.util.spec_from_file_location("image_proxy", MODULE_PATH)
+image_proxy = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(image_proxy)
+
+proxy_content_images = image_proxy.proxy_content_images
+proxy_image_url = image_proxy.proxy_image_url
+
+
+class ImageProxyTests(unittest.TestCase):
+    def test_proxy_image_url_rewrites_existing_proxy_with_current_base_url(self):
+        old_url = (
+            "http://localhost:5000/api/image?url="
+            "https%3A%2F%2Fmmbiz.qpic.cn%2Fmmbiz_png%2Fabc%2F640%3Fwx_fmt%3Dpng"
+        )
+
+        proxied = proxy_image_url(old_url, "http://localhost:8082")
+
+        self.assertTrue(proxied.startswith("http://localhost:8082/api/image?url="))
+        self.assertNotIn("localhost:5000", proxied)
+        self.assertIn("%2Fmmbiz_png%2Fabc%2F640", proxied)
+
+    def test_proxy_content_images_rewrites_cached_proxy_urls(self):
+        html = (
+            '<p><img data-src="http://localhost:5000/api/image?url='
+            'https%3A%2F%2Fmmbiz.qpic.cn%2Fmmbiz_jpg%2Fabc%2F640%3Fwx_fmt%3Djpeg" /></p>'
+        )
+
+        proxied = proxy_content_images(html, "https://rss.example.com")
+
+        self.assertIn('data-src="https://rss.example.com/api/image?url=', proxied)
+        self.assertIn('src="https://rss.example.com/api/image?url=', proxied)
+        self.assertNotIn("localhost:5000", proxied)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/image_proxy.py
+++ b/utils/image_proxy.py
@@ -8,7 +8,7 @@
 图片 URL 处理工具
 统一处理微信 CDN HTTP 图片转 HTTPS 代理
 """
-from urllib.parse import quote
+from urllib.parse import parse_qs, quote, unquote, urlparse
 
 
 def proxy_image_url(url: str, base_url: str) -> str:
@@ -32,8 +32,13 @@ def proxy_image_url(url: str, base_url: str) -> str:
     if not url:
         return ""
     
-    # 防止重复代理：如果 URL 已经是代理 URL，直接返回
+    # 如果 URL 已经是代理 URL，则抽出原始图片地址并改写到当前 base_url。
+    # 这样旧缓存里残留的 localhost:5000 之类地址也能在当前端口继续可用。
     if "/api/image?url=" in url:
+        parsed = urlparse(url)
+        raw_url = parse_qs(parsed.query).get("url", [""])[0]
+        if raw_url:
+            return f"{base_url.rstrip('/')}/api/image?url={quote(unquote(raw_url), safe='')}"
         return url
     
     # 只代理微信 CDN 的图片

--- a/utils/rss_streaming.py
+++ b/utils/rss_streaming.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from html import escape as html_escape
 from typing import Iterator
 
-from utils.image_proxy import proxy_image_url
+from utils.image_proxy import proxy_content_images, proxy_image_url
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +47,8 @@ def _build_item_xml(article: dict, base_url: str) -> str:
     title_escaped = html_escape(title)
     
     content_html = article.get("content", "")
+    if content_html:
+        content_html = proxy_content_images(content_html, base_url)
     html_parts = []
     
     if content_html:


### PR DESCRIPTION
## Summary
- Normalize already-proxied `/api/image?url=...` image URLs using the current RSS base URL.
- Re-process stored article content images when generating RSS feeds.
- Add tests for stale proxy URLs such as old localhost/port values.

## Why
Articles may already be stored with proxied image URLs generated under a previous `SITE_URL`, host, port, or reverse proxy setup. In that case, RSS output can keep emitting stale image proxy URLs even after deployment configuration is corrected.

This keeps old RSS items from pointing at outdated hosts/ports while preserving the existing image proxy behavior.

## Test
- `python3 -m unittest tests/test_image_proxy.py`
